### PR TITLE
Increase throughput for calculation

### DIFF
--- a/api/src/main/java/com/example/poipricing/api/DemoApplication.java
+++ b/api/src/main/java/com/example/poipricing/api/DemoApplication.java
@@ -1,5 +1,9 @@
 package com.example.poipricing.api;
 
+import java.io.File;
+import java.io.FileInputStream;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.springframework.context.annotation.Bean;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
@@ -10,4 +14,11 @@ public class DemoApplication {
 		SpringApplication.run(DemoApplication.class, args);
 	}
 
+	@Bean
+  public XSSFWorkbook getWorkbook() throws Exception {
+		FileInputStream file = new FileInputStream(new File("CountriesDetails.xlsx"));
+		XSSFWorkbook workbook = new XSSFWorkbook(file);
+		
+    return workbook;
+  }
 }

--- a/api/src/main/java/com/example/poipricing/api/DemoApplication.java
+++ b/api/src/main/java/com/example/poipricing/api/DemoApplication.java
@@ -1,9 +1,5 @@
 package com.example.poipricing.api;
 
-import java.io.File;
-import java.io.FileInputStream;
-import org.apache.poi.xssf.usermodel.XSSFWorkbook;
-import org.springframework.context.annotation.Bean;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
@@ -13,12 +9,4 @@ public class DemoApplication {
 	public static void main(String[] args) {
 		SpringApplication.run(DemoApplication.class, args);
 	}
-
-	@Bean
-  public XSSFWorkbook getWorkbook() throws Exception {
-		FileInputStream file = new FileInputStream(new File("CountriesDetails.xlsx"));
-		XSSFWorkbook workbook = new XSSFWorkbook(file);
-		
-    return workbook;
-  }
 }

--- a/api/src/main/java/com/example/poipricing/api/config/SyncWorkbook.java
+++ b/api/src/main/java/com/example/poipricing/api/config/SyncWorkbook.java
@@ -1,0 +1,45 @@
+package com.example.poipricing.api.config;
+
+import java.io.File;
+import java.io.FileInputStream;
+import org.apache.poi.xssf.usermodel.XSSFSheet;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.apache.poi.ss.util.CellReference;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.CellValue;
+import org.apache.poi.ss.usermodel.FormulaEvaluator;
+
+public class SyncWorkbook {
+  private XSSFWorkbook workbook;
+  
+  public SyncWorkbook() throws Exception {
+    FileInputStream file = new FileInputStream(new File("CountriesDetails.xlsx"));
+		this.workbook = new XSSFWorkbook(file);
+  }
+
+  synchronized public double calculate(int value) {
+    Cell cell;
+
+    FormulaEvaluator evaluator = workbook.getCreationHelper().createFormulaEvaluator();
+
+    XSSFSheet sheet = workbook.getSheet("Country");
+    cell = getCell(sheet, "C2");
+    System.out.println("Setting cell value: " + value);
+    cell.setCellValue(value);
+
+
+    cell = getCell(sheet, "C7");
+    CellValue calculated = evaluator.evaluate(cell);
+
+    return calculated.getNumberValue();
+  }
+
+  private Cell getCell(XSSFSheet sheet, String addr) {
+    CellReference cellReference = new CellReference(addr);
+    Row row = sheet.getRow(cellReference.getRow());
+    Cell cell = row.getCell(cellReference.getCol()); 
+
+    return cell;
+  }
+}

--- a/api/src/main/java/com/example/poipricing/api/config/WorkbookConfig.java
+++ b/api/src/main/java/com/example/poipricing/api/config/WorkbookConfig.java
@@ -1,0 +1,14 @@
+package com.example.poipricing.api.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class WorkbookConfig {
+	@Bean
+  public SyncWorkbook getWorkbook() throws Exception {
+		SyncWorkbook syncWorkbook = new SyncWorkbook();
+		
+    return syncWorkbook;
+  }
+}

--- a/api/src/main/java/com/example/poipricing/api/controllers/QuotationController.java
+++ b/api/src/main/java/com/example/poipricing/api/controllers/QuotationController.java
@@ -1,5 +1,6 @@
 package com.example.poipricing.api.controllers;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -23,13 +24,14 @@ import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 
 @RestController
 public class QuotationController {
+  @Autowired
+  XSSFWorkbook workbook;
+  
   @GetMapping("/calculate/{value}")
   @ResponseBody
   public double calculate(@PathVariable int value) throws Throwable {
     Cell cell = null;
 
-    FileInputStream file = new FileInputStream(new File("CountriesDetails.xlsx"));
-    XSSFWorkbook workbook = new XSSFWorkbook(file);
     FormulaEvaluator evaluator = workbook.getCreationHelper().createFormulaEvaluator();
 
     XSSFSheet sheet = workbook.getSheet("Country");

--- a/api/src/main/java/com/example/poipricing/api/controllers/QuotationController.java
+++ b/api/src/main/java/com/example/poipricing/api/controllers/QuotationController.java
@@ -12,11 +12,9 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.Row;
-import org.apache.poi.ss.usermodel.CellValue;
-import org.apache.poi.ss.usermodel.FormulaEvaluator;
-import org.apache.poi.ss.util.CellReference;
 import org.apache.poi.xssf.usermodel.XSSFSheet;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import com.example.poipricing.api.config.SyncWorkbook;
 
 /**
  * QuotationController
@@ -25,25 +23,12 @@ import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 @RestController
 public class QuotationController {
   @Autowired
-  XSSFWorkbook workbook;
+  SyncWorkbook workbook;
   
   @GetMapping("/calculate/{value}")
   @ResponseBody
   public double calculate(@PathVariable int value) throws Throwable {
-    Cell cell = null;
-
-    FormulaEvaluator evaluator = workbook.getCreationHelper().createFormulaEvaluator();
-
-    XSSFSheet sheet = workbook.getSheet("Country");
-    cell = getCell(sheet, "C2");
-    System.out.println("Setting cell value: " + value);
-    cell.setCellValue(value);
-
-
-    cell = getCell(sheet, "C7");
-    CellValue calculated = evaluator.evaluate(cell);
-
-    return calculated.getNumberValue();
+    return workbook.calculate(value);
   }
 
   @GetMapping("/generate")
@@ -98,13 +83,5 @@ public class QuotationController {
     } finally {
       // workbook.close();
     }
-  }
-
-  private Cell getCell(XSSFSheet sheet, String addr) {
-    CellReference cellReference = new CellReference(addr);
-    Row row = sheet.getRow(cellReference.getRow());
-    Cell cell = row.getCell(cellReference.getCol()); 
-
-    return cell;
   }
 }


### PR DESCRIPTION
Using a singleton workbook with synchronized access:

* Increase throughput from ~1.2K to ~9-10K rps
* Decrease metaspace memory slightly from 41MB to 39MB

fixes https://github.com/geekyme/poi-pricing/issues/2
Need to be careful of concurrency issues - https://github.com/geekyme/poi-pricing/issues/1