### PR TITLE
Optimize formula evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,6 @@ First, `cd api`. Then:
 | :-----------------: | :---------------: |
 | ![](./loadtest.png) | ![](./memory.png) |
 
-4. (Optional) to run the advanced scenario - `k6 run loadtest/advanced.js --vus 100 --duration 60s`. This one clocks about 250 rps
+4. (Optional) to run the advanced scenario - `k6 run loadtest/advanced.js --vus 100 --duration 60s`. This one clocks about [700 rps](https://github.com/geekyme/poi-pricing/pull/4)
 
 5. (Optional) to run all scenarios - `k6 run loadtest/index.js --vus 100 --duration 60s`

--- a/api/src/main/java/com/example/poipricing/api/config/SyncWorkbook.java
+++ b/api/src/main/java/com/example/poipricing/api/config/SyncWorkbook.java
@@ -32,6 +32,7 @@ public class SyncWorkbook {
     cell = getCell(sheet, "C2");
     System.out.println("Setting cell value: " + value);
     cell.setCellValue(value);
+    simpleFormula.notifyUpdateCell(cell);
 
 
     cell = getCell(sheet, "C7");
@@ -41,19 +42,32 @@ public class SyncWorkbook {
   }
 
   synchronized public double calculateAdvanced(double medicard, double managedCare, double privateInsurance, double selfPay) {
+    Cell cell;
     XSSFSheet inputSheet = advancedWorkbook.getSheet("2A- Data Entry Worksheet");
     XSSFSheet outputSheet = advancedWorkbook.getSheet("2B- Est. Rev. Proj. Wksheet");
+
     System.out.println("Setting medicard: " + medicard);
-    getCell(inputSheet, "B6").setCellValue(medicard);
+    cell = getCell(inputSheet, "B6");
+    cell.setCellValue(medicard);
+    advancedFormula.notifyUpdateCell(cell);
+
     System.out.println("Setting managedCare: " + managedCare);
-    getCell(inputSheet, "B7").setCellValue(managedCare);
+    cell = getCell(inputSheet, "B7");
+    cell.setCellValue(managedCare);
+    advancedFormula.notifyUpdateCell(cell);
+
     System.out.println("Setting privateInsurance: " + privateInsurance);
-    getCell(inputSheet, "B8").setCellValue(privateInsurance);
+    cell = getCell(inputSheet, "B8");
+    cell.setCellValue(privateInsurance);
+    advancedFormula.notifyUpdateCell(cell);
+
     System.out.println("Setting selfPay: " + selfPay);
-    getCell(inputSheet, "B9").setCellValue(selfPay);
+    cell = getCell(inputSheet, "B9");
+    cell.setCellValue(selfPay);
+    advancedFormula.notifyUpdateCell(cell);
     
     // result
-    Cell cell = getCell(outputSheet, "L80");
+    cell = getCell(outputSheet, "L80");
     CellValue calculated = advancedFormula.evaluate(cell);
 
     return calculated.getNumberValue();

--- a/api/src/main/java/com/example/poipricing/api/config/SyncWorkbook.java
+++ b/api/src/main/java/com/example/poipricing/api/config/SyncWorkbook.java
@@ -13,18 +13,20 @@ import org.apache.poi.ss.usermodel.FormulaEvaluator;
 public class SyncWorkbook {
   private XSSFWorkbook simpleWorkbook;
   private XSSFWorkbook advancedWorkbook;
+  private FormulaEvaluator simpleFormula;
+  private FormulaEvaluator advancedFormula;
   
   public SyncWorkbook() throws Exception {
     FileInputStream simple = new FileInputStream(new File("SimpleCalculation.xlsx"));
     FileInputStream advanced = new FileInputStream(new File("AdvancedCalculation.xlsx"));
     this.simpleWorkbook = new XSSFWorkbook(simple);
     this.advancedWorkbook = new XSSFWorkbook(advanced);
+    this.simpleFormula = this.simpleWorkbook.getCreationHelper().createFormulaEvaluator();
+    this.advancedFormula = this.advancedWorkbook.getCreationHelper().createFormulaEvaluator();
   }
 
   synchronized public double calculateSimple(int value) {
     Cell cell;
-
-    FormulaEvaluator evaluator = simpleWorkbook.getCreationHelper().createFormulaEvaluator();
 
     XSSFSheet sheet = simpleWorkbook.getSheet("Country");
     cell = getCell(sheet, "C2");
@@ -33,14 +35,12 @@ public class SyncWorkbook {
 
 
     cell = getCell(sheet, "C7");
-    CellValue calculated = evaluator.evaluate(cell);
+    CellValue calculated = simpleFormula.evaluate(cell);
 
     return calculated.getNumberValue();
   }
 
   synchronized public double calculateAdvanced(double medicard, double managedCare, double privateInsurance, double selfPay) {
-    FormulaEvaluator evaluator = advancedWorkbook.getCreationHelper().createFormulaEvaluator();
-
     XSSFSheet inputSheet = advancedWorkbook.getSheet("2A- Data Entry Worksheet");
     XSSFSheet outputSheet = advancedWorkbook.getSheet("2B- Est. Rev. Proj. Wksheet");
     System.out.println("Setting medicard: " + medicard);
@@ -54,7 +54,7 @@ public class SyncWorkbook {
     
     // result
     Cell cell = getCell(outputSheet, "L80");
-    CellValue calculated = evaluator.evaluate(cell);
+    CellValue calculated = advancedFormula.evaluate(cell);
 
     return calculated.getNumberValue();
   }


### PR DESCRIPTION
Old = initializing a FormulaEvaluator each time
* this means all caches are evicted
* some overheads with creating a new FormulaEvaluator

New = use a single formula evaluator
* cache is preserved
* so need to notify the evaluator which cell is updated.

3X improvement in advanced case.

Before:
<img width="699" alt="Screenshot 2020-01-10 at 5 28 39 PM" src="https://user-images.githubusercontent.com/977460/72141936-b1f31980-33ce-11ea-9ef0-4ddf974780a3.png">


After:
<img width="692" alt="Screenshot 2020-01-10 at 5 28 12 PM" src="https://user-images.githubusercontent.com/977460/72141955-b61f3700-33ce-11ea-8766-18a87b3370b6.png">

